### PR TITLE
Allow unconditional CUDA build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import os
 from setuptools import setup
+
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from torch.cuda import is_available
 
@@ -6,6 +8,8 @@ cuda_extension = CUDAExtension(
             'fused_adan', 
             sources=['fused_adan/pybind_adan.cpp','./fused_adan/fused_adan_kernel.cu', './fused_adan/multi_tensor_adan_kernel.cu']
         )
+
+build_cuda_ext = is_available() or os.getenv('FORCE_CUDA', '0') == '1'
 
 setup(
     name='adan',
@@ -21,6 +25,6 @@ setup(
         'Xie, Xingyu and Zhou, Pan and Li, Huan and '
         'Lin, Zhouchen and Yan, Shuicheng'
     ),
-    ext_modules=[cuda_extension] if is_available() else [],
-    cmdclass={'build_ext': BuildExtension} if is_available() else {},
+    ext_modules=[cuda_extension] if build_cuda_ext else [],
+    cmdclass={'build_ext': BuildExtension} if build_cuda_ext else {},
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ build_cuda_ext = is_available() or os.getenv('FORCE_CUDA', '0') == '1'
 setup(
     name='adan',
     python_requires='>=3.8',
-    version='0.0.1',
+    version='0.0.2',
     install_requires=['torch'],
     py_modules=['adan'],
     description=(


### PR DESCRIPTION
Sometimes I have to compile packages on a non-CUDA machine and later use that compilation on a CUDA machine.
This PR unconditionally builds the CUDA extension when `FORCE_CUDA=1` is set.

Also I tried to give helpful warnings when users stumble upon the same error; also, we error out early if the user does not have a GPU but tries using fused Adan.

Finally, I took the opportunity to also include an increase in the version string here. That way, when people `pip install -U ...Adan.git`, they get fused Adan without having to force-reinstall the package (otherwise `pip` does not see that there's a new feature available).