### PR TITLE
Update unfused install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ ______________________________________________________________________
 ```
 python3 -m pip install git+https://github.com/sail-sg/Adan.git
 ```
+FusedAdan is installed by default. If you want to use the original Adan, please install it by:
+```
+git clone https://github.com/sail-sg/Adan.git
+cd Adan
+python3 setup.py install --unfused
+```
 
-FusedAdan is installed by default. A brief comparison of peak memory and wall duration for the optimizer is as follows. The duration time is the total time of 200 `optimizer.step()`. We further compare Adam and FusedAdan in great detail on GPT-2. See more results [here](./fused_adan/README.md).
+A brief comparison of peak memory and wall duration for the optimizer is as follows. The duration time is the total time of 200 `optimizer.step()`. We further compare Adam and FusedAdan in great detail on GPT-2. See more results [here](./fused_adan/README.md).
 
 | Model      | Model Size (MB) | Adam Peak (MB) | Adan Peak (MB) | FusedAdan Peak (MB) | Adam Time (ms) | Adan Time (ms) | FusedAdan Time (ms) |
 | :--------- | :-------------: | :------------: | :------------: | :-----------------: | :------------: | :------------: | :-----------------: |

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 import os
+import sys
 from setuptools import setup
 
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from torch.cuda import is_available
 
-cuda_extension = CUDAExtension(
+if "--unfused" in sys.argv:
+    print("Building unfused version of adan")
+    sys.argv.remove("--unfused")
+else:
+    cuda_extension = CUDAExtension(
             'fused_adan', 
             sources=['fused_adan/pybind_adan.cpp','./fused_adan/fused_adan_kernel.cu', './fused_adan/multi_tensor_adan_kernel.cu']
         )


### PR DESCRIPTION
If someone want to use unfused version, they can just clone repo and use original setup.py with `--unfused` to install Adan.