### PR TITLE
Handle empty parameter list

### DIFF
--- a/adan.py
+++ b/adan.py
@@ -193,6 +193,9 @@ class Adan(Optimizer):
                 exp_avg_diffs.append(state['exp_avg_diff'])
                 neg_pre_grads.append(state['neg_pre_grad'])
 
+            if not params_with_grad:
+                continue
+
             kwargs = dict(
                 params=params_with_grad,
                 grads=grads,

--- a/fused_adan/multi_tensor_adan_kernel.cu
+++ b/fused_adan/multi_tensor_adan_kernel.cu
@@ -165,6 +165,10 @@ void multi_tensor_adan_cuda(
   const float clip_global_grad_norm)
 {
   using namespace at;
+  TORCH_CHECK(!tensor_lists.empty(), "tensor list cannot be empty")
+  if (tensor_lists[0].empty()) {
+    return;
+  }
 
   // Assume single type across p,g,m1,m2 now
   DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(


### PR DESCRIPTION
If `params_with_grad` remains empty, the fused CUDA kernel will crash without error due to [trying to index into an empty list](https://github.com/sail-sg/Adan/blob/8362d90a8f8f9c9315177d193c24094b1a610308/fused_adan/multi_tensor_adan_kernel.cu#L171). This PR first fixes the CUDA kernel so it throws a more meaningful error.
In addition, in Python, it skips the whole dispatching to update sub-functions whenever the `params_with_grad` list is empty. This is also necessary because empty lists aren't handled in [`torch.__foreach__` functions either](https://github.com/sail-sg/Adan/blob/95f3096044c547c98d062bb01507457b7c64246f/adan.py#L394).